### PR TITLE
options.color background color for text on progress bar if no gradient

### DIFF
--- a/Source/progressbar.js
+++ b/Source/progressbar.js
@@ -39,7 +39,7 @@ provides: [ProgressBar]
 			
 			if(typeof options.gradient == 'boolean') options.gradient = [options.color, options.fillColor];
 			
-			options.gradient = options.gradient ? this.getBackground(options.gradient) : options.color;
+			options.gradient = options.gradient ? this.getBackground(options.gradient) : options.fillColor;
 					
 			var container = document.id(this.options.container),
 				width = this.width = options.width || container.getStyle('width').toInt() || 1,


### PR DESCRIPTION
gives non-visible text. it's better to use options.fillColor there
